### PR TITLE
g2-config: don't simply kill ~/.gitconfig, move it instead

### DIFF
--- a/g2-config.sh
+++ b/g2-config.sh
@@ -53,7 +53,7 @@ LOCKFILE=$(which lockfile)
 [[ -n $LOCKFILE ]] && lockfile -2 -r 3 /tmp/git-config.lock
 
 save_config
-rm -f ~/.gitconfig
+test -f ~/.gitconfig && mv -f ~/.gitconfig ~/.gitconfig.pre-g2
 apply_config
 
 $GIT_EXE config --global core.excludesfile ~/.gitignore_global


### PR DESCRIPTION
Signed-off-by: Stefan Naewe stefan.naewe@gmail.com
