### PR TITLE
Made custom prompt optional; suppressed output that confuses sftp.

### DIFF
--- a/bash/g2-install.sh
+++ b/bash/g2-install.sh
@@ -41,22 +41,12 @@ tips=(
 "Remember, you may always access the native git command using \"\$GIT_EXE\"."
 "Unlike git, ${boldon}g2${boldoff} actions only apply to the current branch.");
 
-echo -n -e "Installing ${boldon}G2${boldoff}.."
-
 source ./g2-completion.sh
-echo -n "."
 source ./g2-config.sh
-echo -n "."
 source ./g2.sh
-echo -n "."
 source ./g2-prompt.sh
 
 alias g=__g2_eval;
 alias git=__g2_eval;
-
-echo " Enjoy!"
-
-echo -e "${boldon}Tip of the day${boldoff}: ${tips[RANDOM % ${#tips[@]}]} ${reset}"
-
 
 cd $OLDpwd

--- a/bash/g2-prompt.sh
+++ b/bash/g2-prompt.sh
@@ -18,7 +18,7 @@ fi
 
 #####  read config file if any.
 
-unset dir_color rc_color user_id_color root_id_color init_vcs_color clean_vcs_color
+unset use_prompt dir_color rc_color user_id_color root_id_color init_vcs_color clean_vcs_color
 unset modified_vcs_color added_vcs_color untracked_vcs_color op_vcs_color detached_vcs_color hex_vcs_color
 unset rawhex_len
 
@@ -30,9 +30,13 @@ conf=/etc/g2/g2-prompt.conf;
 if [ -r $conf ]; then . $conf; fi
 conf=/etc/g2-prompt.conf;
 if [ -r $conf ]; then . $conf; fi
-conf=~/.g2-prompt.conf;
+conf="$HOME/.g2-prompt.conf";
 if [ -r $conf ]; then . $conf; fi
 unset conf
+
+if [[ $use_prompt = "off" ]]; then
+	return;
+fi
 
 
 #####  set defaults if not set


### PR DESCRIPTION
I noticed that the output when installing g2 is confusing sftp (with the scp command for example). So I've stripped it off completely.

Also some users may not want to part with their favourite prompts even though they'd lose the branch indication etc. So I've added a configuration option to short out the g2 prompt altogether.

I'd understand if you want to keep the g2-install output, then maybe I could alter the patch to make it configurable; I'm open to suggestions.